### PR TITLE
Assessment: Rate Limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+COPY deps /deps
+RUN pip install --no-index --find-links=/deps -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "RateLimiter:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/RateLimiter.py
+++ b/RateLimiter.py
@@ -1,0 +1,50 @@
+from fastapi import FastAPI, Request
+from starlette.responses import JSONResponse
+import time
+import json
+
+app = FastAPI()
+
+# Load request log from file
+try:
+    with open("state.json", "r") as syakir_file:
+        request_log = json.load(syakir_file)
+except FileNotFoundError:
+    request_log = {}
+
+# Config
+ENDPOINT = "/limited"
+RATE_LIMIT = 4
+
+@app.middleware("http")
+async def rate_limiter(request: Request, call_next):
+    ip = request.client.host
+    now = time.time()
+    key = f"{ip}:{request.url.path}"
+
+    logs = request_log.get(key, [])
+    logs = [timestamp for timestamp in logs if now - timestamp < 1]
+
+    if request.url.path == ENDPOINT and len(logs) >= RATE_LIMIT:
+        print(f"LIMITED: {ip} hit the limit ({len(logs)} reqs/sec)")
+        return JSONResponse(status_code=429, content={"detail": "Too many requests"})
+
+    logs.append(now)
+    request_log[key] = logs
+
+    if request.url.path == ENDPOINT:
+        print(f"ALLOWED: {ip} → {len(logs)} request in 1s")
+
+    with open("state.json", "w") as syakir_file:
+        json.dump(request_log, syakir_file)
+
+    response = await call_next(request)
+    return response
+
+@app.get("/")
+def home():
+    return {"message": "Rate limits user request"}
+
+@app.get(ENDPOINT)
+def limited():
+    return {"message": "Request allowed"}

--- a/deploy.yaml
+++ b/deploy.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1 
+kind: Deployment
+metadata:
+  name: rate-limiter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rate-limiter
+  template:
+    metadata:
+      labels:
+        app: rate-limiter
+    spec:
+      containers:
+      - name: rate-limiter
+        image: rate-limiter-app
+        imagePullPolicy: Never
+        ports:
+        - containerPort: 8000

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/service.yaml
+++ b/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rate-limiter-service
+spec:
+  selector:
+    app: rate-limiter
+  ports:
+    - protocol: TCP
+      port: 8000
+      targetPort: 8000
+  type: NodePort


### PR DESCRIPTION
Summary:
This rate-limiting HTTP service uses FastAPI in Python. Its primary objective is to restrict the number of requests a user can make to a specific endpoint within a defined time window. The rate limiter uses the client's IP address to track and control the number of requests. If the user exceeds the configured limit, the service responds with a 429 HTTP status code, indicating too many requests. The request log is saved persistently in a JSON file (state.json) so that the limiter can recover after service restarts or crashes.

The application is built with Python’s FastAPI framework and served using Uvicorn. It is fully containerized using Docker and deployed to a local Kubernetes cluster via Minikube. The service exposes a Swagger UI at /docs for API interaction and testing.
